### PR TITLE
Bump spring-boot-starter-parent from 2.1.0.RELEASE to 2.1.6.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.0.RELEASE</version>
+        <version>2.1.6.RELEASE</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
Bumps spring-boot-starter-parent from 2.1.0.RELEASE to 2.1.6.RELEASE.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

(Copy of dependabot's https://github.com/contently/html-diff-service/pull/8, since the `infra` command can't handle _slashes_ in a branch name, yet)